### PR TITLE
Command parsing #12

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -108,3 +108,6 @@ venv.bak/
 .mypy_cache/
 .dmypy.json
 dmypy.json
+
+# editor config
+.vscode/

--- a/parser.py
+++ b/parser.py
@@ -1,0 +1,33 @@
+# expects: messsage (string)
+# getCommand(message) returns 
+def getCommand(message):
+  message = message.strip()
+  split_message = message.split()
+  if len(split_message) > 0:
+    command = split_message[0].strip()
+    if len(command) > 1 and command[0] == '/':
+      return command[1:]
+  return False
+
+# expects: message (string)
+# getArguments(message) returns an in-order array of the arguments provided with a command.
+# This does not check if a message contains a command. Call getCommand to check first.
+def getArguments(message):
+  message = message.strip()
+  split_message = message.split()
+  if len(split_message) > 1:
+    # Whitespace around args already removed by .split()
+    return split_message[1:]
+  return []
+
+# expects: message (string)
+# getAvatar(message) returns the first argument following a '/avatar' command.
+def getAvatar(message):
+  command = getCommand(message)
+  if command == 'avatar':
+    arguments = getArguments(message)
+    if len(arguments) > 0:
+      return arguments[0]
+    # return '' here so that the avatar command is still validated
+    return ''
+  return False

--- a/parser_test.py
+++ b/parser_test.py
@@ -1,0 +1,38 @@
+import unittest
+import parser
+
+class TestAvatar(unittest.TestCase):
+  def test_no_avatar(self):
+      self.assertEqual(parser.getAvatar('Hello'), False)
+
+  def test_avatar(self):
+    self.assertEqual(parser.getAvatar('/avatar Happy'), 'Happy')
+  
+  def test_with_whitespace(self):
+    self.assertEqual(parser.getAvatar(' \t /avatar \t  \n Happy\n\t '), 'Happy')
+  
+  def test_empty(self):
+    self.assertEqual(parser.getAvatar(''), False)
+  
+  def test_no_value(self):
+    self.assertEqual(parser.getAvatar('/avatar'), '')
+
+class TestCommand(unittest.TestCase):
+  def test_no_command(self):
+    self.assertEqual(parser.getCommand('This is a test!'), False)
+
+  def test_command(self):
+    self.assertEqual(parser.getCommand('/wizard'), 'wizard')
+  
+  def test_arguments(self):
+    self.assertEqual(parser.getArguments('/connect 127.0.0.1 8080'), ['127.0.0.1', '8080'])
+
+  def test_no_arguments(self):
+    self.assertEqual(parser.getArguments('/connect'), [])
+  
+  def test_empty(self):
+    self.assertEqual(parser.getCommand(''), False)
+    self.assertEqual(parser.getArguments(''), [])
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
# Command Parsing - Card #12
[Trello Card #12](https://trello.com/c/JMYjnfro)

## Problem/Goal
Add simple parsing for the /avatar command.
Return False if no avatar command is used.
Return the desired avatar state if the '/avatar' command is used.

## Solution
Created parser.py
Static functions `getCommand(message)` and `getArguments(message)` provide general purpose parsing for any command beginning with '/'.
`getCommand` returns the command used.
`getArguments` returns an array of arguments that follow, in order (or [] for no arguments)

`getAvatar(message)` uses these to check for the '/avatar' command and returns the first argument.

Example:
```python3
message = '/avatar Happy'
print(getAvatar(message))
# prints 'Happy'
```

## Verification Steps
1. Check out branch `command-parsing`
```
git fetch
git checkout origin/command-parsing
```

2. Run tests in `parser_test.py`
```
python3 -m unittest parser_test.py 
```