### PR TITLE
Fix dorothy failing to parse avatar commands

### DIFF
--- a/gui.py
+++ b/gui.py
@@ -30,7 +30,7 @@ def listenForMsg():
             # parse message for avatar commands
             avatar_state = False
             if not Im_a_wizard_harry:
-                avatar_state = parser.getAvatar(message)
+                avatar_state = parser.getAvatar(msg)
             if avatar_state != False:
                 avatar_state_var.set(avatar_state)
             else:


### PR DESCRIPTION
## Problem / Goal
Dorothy was getting the following error when a wizard sent the message "/avatar happy"
```
Exception in thread Thread-2:
Traceback (most recent call last):
  File "/usr/lib/python3.6/threading.py", line 916, in _bootstrap_inner
    self.run()
  File "/usr/lib/python3.6/threading.py", line 864, in run
    self._target(*self._args, **self._kwargs)
  File "gui.py", line 33, in listenForMsg
    avatar_state = parser.getAvatar(message)
NameError: name 'message' is not defined
```

## Solution
The proper variable name is `msg` where `message` was used.
(Admittedly I should have caught this during code review oops)

## Verification
1. Start server
2. Start two gui.py instances
3. Elevate one side to the wizard
4. As the wizard, send "/avatar happy"
5. Avatar changes for the wizard
7. Avatar changes for dorothy