### PR TITLE
Bug Fix: TTS name parsing

### DIFF
--- a/gui.py
+++ b/gui.py
@@ -4,6 +4,7 @@ from tkinter import *
 from client import *
 from server import *
 from easygui import enterbox, multenterbox, exceptionbox
+import re
 import time
 import datetime
 import parser
@@ -175,7 +176,11 @@ def text_to_speech(msg):
     # only use text to speech for messages from other user and if text to speech is turned on
     if not msg.startswith(name.rstrip()) and (ttsToggle["text"] == "On"):
         msg.rstrip()
-        msg = msg[len(name):len(msg)]
+        start_idx = 0;
+        start_regex = re.search(r':\s*', msg)
+        if start_regex != None:
+            start_idx = start_regex.end();
+        msg = msg[start_idx:len(msg)]
         tts = gTTS(text=msg, lang='en', slow=False)
         tts.save("tts.mp3")
         os.system("mpg123 tts.mp3")
@@ -211,6 +216,10 @@ if __name__=="__main__":
     ipaddr = ipaddr.strip()
     portno = portno.strip()
     name   = name.strip()
+    # name must not contain character ':'
+    contains_colon = re.search(r':', name)
+    if contains_colon != None:
+        name = ''
     wizard_in = wizard_in.strip()
 
     while (ipaddr == '' or portno == '' or name == ''):
@@ -221,6 +230,10 @@ if __name__=="__main__":
         ipaddr = ipaddr.strip()
         portno = portno.strip()
         name = name.strip()
+        # name must not contain character ':'
+        contains_colon = re.search(r':', name)
+        if contains_colon != None:
+            name = ''
         wizard_in = wizard_in.strip()
 
     try:


### PR DESCRIPTION
### Problem

When reading a message, the TTS feature attempts to ignore the username by ignoring the first x characters of the message, where x is the length of the current user's name. If the usernames of the two users differ in length, then TTS will ignore part of the message when reading to the user with the longer name, and it will read part of the sender's username to the user with the shorter name.

### Solution

I used regular expressions to parse out the username of a message before TTS reads it. The regular expression searches the message for the first colon. It then begins reading at the first non white space character after the colon.
To make this solution work, we can't allow users to have colons in their usernames, so I added code to the startup process to disallow usernames with colons. When the user enters their information, I use regular expressions to search the name for a colon. If the name contains a colon, I clear the name field, forcing the code to prompt the user for input again.
In gui.py line 219 and 233:
`    # name must not contain character ':'
contains_colon = re.search(r':', name)
if contains_colon != None:
    name = ''
`

### Verification

1. Start Two instances of the application on the same machine
2. Attempt to start first user with IP 127.0.0.1, port 8080, and name "Wizard:" (name containing colon)
    Expected behavior: Startup window should reopen with all fields empty
3. Attempt to start first user with IP 127.0.0.1, port 8080, and name "a" (single character name)
4. Attempt to start second user with IP 127.0.0.1, port 8080, and name "much longer name" (name with many more characters)
5. Send messages between users with TTS on.
    Expected behavior: On each end, entire message should be read excluding the entire username.