### PR TITLE
Add try-except to speech recognizer

### DIFF
--- a/speech.py
+++ b/speech.py
@@ -4,7 +4,10 @@ r = sr.Recognizer()
 mic = sr.Microphone()
 
 def record_and_recognize():
-	with mic as source:
-		r.adjust_for_ambient_noise(source)
-		audio = r.listen(source)
-	return r.recognize_google(audio)
+	try:
+		with mic as source:
+			r.adjust_for_ambient_noise(source)
+			audio = r.listen(source)
+		return r.recognize_google(audio)
+	except:
+		return ""


### PR DESCRIPTION
## Problem
Unrecognizable speech threw an UnknownValue error from `recognize_google()`.

The error was not being caught, so it panicked.

## Solution
Added a try-catch to the speech recognition function.
If speech is not recognized, it returns the empty string.